### PR TITLE
Fix for dropdowns being displayed while menu is collapsed

### DIFF
--- a/login_buttons_dropdown.html
+++ b/login_buttons_dropdown.html
@@ -2,7 +2,7 @@
 <!-- LOGGED IN -->
 <!--           -->
 <template name="_loginButtonsLoggedInDropdown">
-  <div class="nav-collapse">
+  <div class="nav-collapse collapse">
     <ul class="nav pull-right">
       <li id="login-dropdown-list" class="dropdown">
         <a class="dropdown-toggle" href="#" data-toggle="dropdown">{{displayName}}<strong class="caret"></strong></a>
@@ -33,7 +33,7 @@
 <!-- LOGGED OUT -->
 <!--            -->
 <template name="_loginButtonsLoggedOutDropdown">
-  <div class="nav-collapse">
+  <div class="nav-collapse collapse">
     <ul class="nav pull-right">
       <li id="login-dropdown-list" class="dropdown">
         <a class="dropdown-toggle" href="#" data-toggle="dropdown">Sign In / Up <strong class="caret"></strong></a>


### PR DESCRIPTION
For the dropdowns to be displayed correctly while the nav bar is collapsed:

`<div class="nav-collapse">`

was changed to:

`<div class="nav-collapse collapse">`

The collapse logic expects the collapsible element to already have class "collapse".

The "collapse" class gets added when you expand the nav (if it is not already present), which is why the dropdown menu currently works only when you open, close, and then re-open the nav a second time.
