### PR TITLE
Fix dropdown not appearing on first click when collapsed

### DIFF
--- a/login_buttons_dropdown.html
+++ b/login_buttons_dropdown.html
@@ -2,7 +2,7 @@
 <!-- LOGGED IN -->
 <!--           -->
 <template name="_loginButtonsLoggedInDropdown">
-  <div class="nav-collapse">
+  <div class="nav-collapse collapse">
     <ul class="nav pull-right">
       <li id="login-dropdown-list" class="dropdown">
         <a class="dropdown-toggle" href="#" data-toggle="dropdown">{{displayName}}<strong class="caret"></strong></a>
@@ -33,7 +33,7 @@
 <!-- LOGGED OUT -->
 <!--            -->
 <template name="_loginButtonsLoggedOutDropdown">
-  <div class="nav-collapse">
+  <div class="nav-collapse collapse">
     <ul class="nav pull-right">
       <li id="login-dropdown-list" class="dropdown">
         <a class="dropdown-toggle" href="#" data-toggle="dropdown">Sign In / Up <strong class="caret"></strong></a>


### PR DESCRIPTION
The `.nav-collapse` on a collapsible navbar in Twitter Bootstrap also requires the `.collapse` class. https://github.com/twitter/bootstrap/issues/5671#issuecomment-10259395
